### PR TITLE
[Refactor] 리뷰 도메인에 주문상세 연관관계 및 검증 로직 추가

### DIFF
--- a/src/main/java/com/irum/productservice/domain/review/domain/entity/Review.java
+++ b/src/main/java/com/irum/productservice/domain/review/domain/entity/Review.java
@@ -1,5 +1,7 @@
 package com.irum.productservice.domain.review.domain.entity;
 
+import com.irum.productservice.domain.member.domain.entity.Member;
+import com.irum.productservice.domain.order.domain.entity.OrderDetail;
 import com.irum.productservice.domain.product.domain.entity.Product;
 import com.irum.productservice.global.domain.BaseEntity;
 import jakarta.persistence.*;
@@ -14,6 +16,7 @@ import org.hibernate.annotations.Where;
 @Entity
 @Table(name = "p_review")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE p_review SET deleted_at = NOW() WHERE review_id = ?")
 @Where(clause = "deleted_at IS NULL")
 @Check(constraints = "rate BETWEEN 1 AND 5")
 public class Review extends BaseEntity {
@@ -23,10 +26,10 @@ public class Review extends BaseEntity {
     @Column(name = "review_id", updatable = false, nullable = false)
     private UUID id;
 
-    @Column(name = "content", columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "rate", nullable = false, columnDefinition = "SMALLINT")
+    @Column(nullable = false, columnDefinition = "SMALLINT")
     private Short rate;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -37,24 +40,33 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_detail_id", unique = true, nullable = false)
+    private OrderDetail orderDetail;
+
     @Builder
-    private Review(String content, Short rate, Member member, Product product) {
+    private Review(
+            String content, Short rate, Member member, Product product, OrderDetail orderDetail) {
         this.content = content;
         this.rate = rate;
         this.member = member;
         this.product = product;
+        this.orderDetail = orderDetail;
     }
 
-    public static Review createReview(String content, Short rate, Member member, Product product) {
-        return Review.builder().content(content).rate(rate).member(member).product(product).build();
+    public static Review createReview(
+            String content, Short rate, Member member, Product product, OrderDetail orderDetail) {
+        return Review.builder()
+                .content(content)
+                .rate(rate)
+                .member(member)
+                .product(product)
+                .orderDetail(orderDetail)
+                .build();
     }
 
     public void updateReview(String content, Short rate) {
-        if (content != null) {
-            this.content = content;
-        }
-        if (rate != null) {
-            this.rate = rate;
-        }
+        if (content != null) this.content = content;
+        if (rate != null) this.rate = rate;
     }
 }

--- a/src/main/java/com/irum/productservice/domain/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/irum/productservice/domain/review/domain/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.irum.productservice.domain.review.domain.repository;
 
+import com.irum.productservice.domain.order.domain.entity.OrderDetail;
 import com.irum.productservice.domain.review.domain.entity.Review;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -13,6 +14,8 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     Page<Review> findAllByMember_MemberId(Long memberId, Pageable pageable);
 
     Page<Review> findAllByProduct_Id(UUID productId, Pageable pageable);
+
+    boolean existsByOrderDetail(OrderDetail orderDetail);
 
     @Query(
             """

--- a/src/main/java/com/irum/productservice/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/irum/productservice/domain/review/dto/request/ReviewCreateRequest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 
 public record ReviewCreateRequest(
+        @NotNull(message = "주문상세 ID는 필수 입력값입니다.") UUID orderDetailId,
         @NotNull(message = "상품 ID는 필수 입력값입니다.") UUID productId,
         @NotBlank(message = "리뷰 내용은 필수 입력값입니다.") String content,
         @NotNull(message = "평점은 필수 입력값입니다.")

--- a/src/main/java/com/irum/productservice/domain/review/service/ReviewService.java
+++ b/src/main/java/com/irum/productservice/domain/review/service/ReviewService.java
@@ -1,6 +1,9 @@
 package com.irum.productservice.domain.review.service;
 
 import com.irum.productservice.domain.member.domain.entity.Member;
+import com.irum.productservice.domain.order.domain.entity.OrderDetail;
+import com.irum.productservice.domain.order.domain.entity.enums.OrderStatus;
+import com.irum.productservice.domain.order.domain.repository.OrderDetailRepository;
 import com.irum.productservice.domain.product.domain.entity.Product;
 import com.irum.productservice.domain.product.domain.repository.ProductRepository;
 import com.irum.productservice.domain.review.domain.entity.Review;
@@ -11,7 +14,7 @@ import com.irum.productservice.domain.review.dto.request.ReviewCreateRequest;
 import com.irum.productservice.domain.review.dto.request.ReviewUpdateRequest;
 import com.irum.productservice.domain.review.dto.response.ReviewResponse;
 import com.irum.productservice.global.presentation.advice.exception.CommonException;
-import com.irum.productservice.global.presentation.advice.exception.errorcode.ProductErrorCode;
+import com.irum.productservice.global.presentation.advice.exception.errorcode.OrderErrorCode;
 import com.irum.productservice.global.presentation.advice.exception.errorcode.ReviewErrorCode;
 import com.irum.productservice.global.util.MemberUtil;
 import java.util.List;
@@ -32,24 +35,32 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewImageRepository reviewImageRepository;
     private final ProductRepository productRepository;
+    private final OrderDetailRepository orderDetailRepository;
     private final MemberUtil memberUtil;
 
     /** 리뷰 생성 */
     public ReviewResponse createReview(ReviewCreateRequest request) {
-        Product product =
-                productRepository
-                        .findById(request.productId())
-                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
-
         Member member = memberUtil.getCurrentMember();
 
-        log.info(
-                "리뷰 작성 요청: memberId={}, productId={}, rate={}",
-                member.getMemberId(),
-                request.productId(),
-                request.rate());
+        OrderDetail detail =
+                orderDetailRepository
+                        .findById(request.orderDetailId())
+                        .orElseThrow(
+                                () -> new CommonException(OrderErrorCode.ORDER_DETAIL_NOT_FOUND));
 
-        Review review = Review.createReview(request.content(), request.rate(), member, product);
+        if (!detail.getOrder().getMember().equals(member))
+            throw new CommonException(OrderErrorCode.ORDER_ACCESS_DENIED);
+
+        if (!detail.getOrderStatusIndi().equals(OrderStatus.DELIVERED))
+            throw new CommonException(ReviewErrorCode.NOT_REVIEWABLE_ORDER);
+
+        if (reviewRepository.existsByOrderDetail(detail))
+            throw new CommonException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
+
+        Product product = detail.getProduct();
+
+        Review review =
+                Review.createReview(request.content(), request.rate(), member, product, detail);
         Review saved = reviewRepository.save(review);
 
         List<ReviewImage> images =
@@ -59,8 +70,19 @@ public class ReviewService {
                                 .map(url -> ReviewImage.create(url, saved))
                                 .toList();
 
-        reviewImageRepository.saveAll(images);
+        try {
+            reviewImageRepository.saveAll(images);
+        } catch (Exception e) {
+            throw new CommonException(ReviewErrorCode.REVIEW_IMAGE_PROCESS_ERROR);
+        }
+
         updateProductRating(product);
+
+        log.info(
+                "리뷰 생성 완료: memberId={}, orderDetailId={}, productId={}",
+                member.getMemberId(),
+                detail.getOrderDetailId(),
+                product.getId());
 
         return ReviewResponse.from(saved, images.stream().map(ReviewImage::getImageUrl).toList());
     }
@@ -72,7 +94,9 @@ public class ReviewService {
                         .findById(reviewId)
                         .orElseThrow(() -> new CommonException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        memberUtil.assertMemberResourceAccess(review.getMember());
+        if (!review.getMember().getMemberId().equals(memberUtil.getCurrentMember().getMemberId())) {
+            throw new CommonException(ReviewErrorCode.REVIEW_UNAUTHORIZED);
+        }
 
         if (request.content() == null && request.rate() == null && request.imageUrls() == null)
             throw new CommonException(ReviewErrorCode.REVIEW_NOT_MODIFIED);
@@ -80,12 +104,18 @@ public class ReviewService {
         review.updateReview(request.content(), request.rate());
 
         if (request.imageUrls() != null) {
-            reviewImageRepository.deleteAll(reviewImageRepository.findAllByReview(review));
+            reviewImageRepository
+                    .findAllByReview(review)
+                    .forEach(img -> img.softDelete(memberUtil.getCurrentMember().getMemberId()));
             List<ReviewImage> newImages =
                     request.imageUrls().stream()
                             .map(url -> ReviewImage.create(url, review))
                             .toList();
-            reviewImageRepository.saveAll(newImages);
+            try {
+                reviewImageRepository.saveAll(newImages);
+            } catch (Exception e) {
+                throw new CommonException(ReviewErrorCode.REVIEW_IMAGE_PROCESS_ERROR);
+            }
         }
 
         List<String> imageUrls =
@@ -102,8 +132,6 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public Page<ReviewResponse> getMyReviews(Pageable pageable) {
         Member member = memberUtil.getCurrentMember();
-        log.info("내 리뷰 목록 조회 요청: memberId={}", member.getMemberId());
-
         return reviewRepository
                 .findAllByMember_MemberId(member.getMemberId(), pageable)
                 .map(
@@ -119,8 +147,6 @@ public class ReviewService {
     /** 상품 리뷰 목록 조회 */
     @Transactional(readOnly = true)
     public Page<ReviewResponse> getProductReviews(UUID productId, Pageable pageable) {
-        log.info("상품 리뷰 목록 조회 요청: productId={}", productId);
-
         return reviewRepository
                 .findAllByProduct_Id(productId, pageable)
                 .map(
@@ -140,8 +166,16 @@ public class ReviewService {
                         .findById(reviewId)
                         .orElseThrow(() -> new CommonException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        reviewImageRepository.deleteAll(reviewImageRepository.findAllByReview(review)); //soft delete 적용 필요
+        if (!review.getMember().getMemberId().equals(memberUtil.getCurrentMember().getMemberId())) {
+            throw new CommonException(ReviewErrorCode.REVIEW_UNAUTHORIZED);
+        }
+
+        reviewImageRepository
+                .findAllByReview(review)
+                .forEach(img -> img.softDelete(memberUtil.getCurrentMember().getMemberId()));
+
         review.softDelete(memberUtil.getCurrentMember().getMemberId());
+
         updateProductRating(review.getProduct());
 
         log.info("리뷰 삭제 완료: reviewId={}", reviewId);

--- a/src/main/java/com/irum/productservice/global/presentation/advice/exception/errorcode/ReviewErrorCode.java
+++ b/src/main/java/com/irum/productservice/global/presentation/advice/exception/errorcode/ReviewErrorCode.java
@@ -11,7 +11,8 @@ public enum ReviewErrorCode implements BaseErrorCode {
     REVIEW_NOT_MODIFIED(HttpStatus.BAD_REQUEST, "리뷰 수정에 대한 변경된 내용이 없습니다."),
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 리뷰입니다."),
     REVIEW_UNAUTHORIZED(HttpStatus.FORBIDDEN, "리뷰에 대한 수정 또는 삭제 권한이 없습니다."),
-    REVIEW_IMAGE_PROCESS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "리뷰 이미지 처리 중 오류가 발생했습니다.");
+    REVIEW_IMAGE_PROCESS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "리뷰 이미지 처리 중 오류가 발생했습니다."),
+    NOT_REVIEWABLE_ORDER(HttpStatus.BAD_REQUEST, "배송 완료된 주문만 리뷰를 작성할 수 있습니다."),
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #4

📌 **작업 내용 및 특이사항**

- Review 엔티티에 OrderDetail 1:1 매핑
- ReviewService에서 주문상세 상태 검증 로직 추가 (DELIVERED 상태만 리뷰 작성 가능)
- 리뷰, 리뷰이미지 soft delete 적용 및 물리 삭제 로직 제거
- 리뷰 수정·삭제 시 작성자 권한 검증 로직 추가 (REVIEW_UNAUTHORIZED 예외 처리)
- createReview 시 existsByOrderDetail 기반 중복 리뷰 방지 유지


📚 **참고사항**
